### PR TITLE
Use latest neovim lsp API

### DIFF
--- a/lua/phpactor/utils.lua
+++ b/lua/phpactor/utils.lua
@@ -21,7 +21,7 @@ function utils.path(bufnr)
 end
 
 function utils.get_root_dir()
-  local buf_clients = vim.lsp.get_clients({ name = "phpactor", bufnr = 0 })
+  local buf_clients = vim.lsp.get_active_clients({ name = "phpactor", bufnr = 0 })
 
   if #buf_clients > 0 then
     return buf_clients[1].config.root_dir


### PR DESCRIPTION
`vim.lsp.get_clients()` is no longer defined. Replaced by `vim.lsp.get_active_clients()`.