### PR TITLE
Allow to use custom utils.path() function

### DIFF
--- a/lua/phpactor/config.lua
+++ b/lua/phpactor/config.lua
@@ -16,6 +16,9 @@ local default_values = {
     enabled = true,
     options = {},
   },
+  utils = {
+    pathFn = nil
+  },
 }
 
 function config.setup(options)

--- a/lua/phpactor/utils.lua
+++ b/lua/phpactor/utils.lua
@@ -1,3 +1,4 @@
+local config = require("phpactor.config")
 local utils = {}
 
 function utils.offset(winnr, bufnr)
@@ -15,6 +16,10 @@ function utils.source(bufnr)
 end
 
 function utils.path(bufnr)
+  if config.options.utils.pathFn ~= nil then
+    return config.options.utils.pathFn(bufnr)
+  end
+
   bufnr = bufnr or 0
 
   return vim.api.nvim_buf_get_name(bufnr)


### PR DESCRIPTION
Hi, I'm using neotree in netrw mode (with `position="current"`) and when I try to use RPCs with interactive menus (the ones processed by `rpc.handle_input_callback()`) I get unwanted results when paths to files or directories are involved.

For example, when I attempt to do `require('phpactor').rpc('new_class')` while in neotree, I get this:
![20231220_01h39m48s_grim](https://github.com/gbprod/phpactor.nvim/assets/16771771/c99c557c-c3db-4ace-87a6-c44de9bca0b7)

It makes sense because that's the name of the current buffer, but not really what needs to be there.

This PR adds a config option in order to allow the plugin to use a custom `utils.path()` function defined at startup. With these changes I've been able to define my own path resolution function (using neotree API), and now my input looks properly, like this:
![20231220_01h41m59s_grim](https://github.com/gbprod/phpactor.nvim/assets/16771771/7eb13134-77a0-45ec-9d8d-c3644d3bbd79)
