### PR TITLE
Migrate LSP to Neovim's native API

### DIFF
--- a/lua/phpactor.lua
+++ b/lua/phpactor.lua
@@ -34,12 +34,16 @@ function phpactor.setup(options)
   vim.schedule(phpactor.check_install)
 
   if config.options.lspconfig.enabled then
-    require("lspconfig").phpactor.setup(vim.tbl_deep_extend("force", {
-      cmd = {
-        config.options.install.bin,
-        "language-server",
-      },
-    }, config.options.lspconfig.options))
+    vim.lsp.config(
+      "phpactor",
+      vim.tbl_deep_extend("force", {
+        cmd = {
+          config.options.install.bin,
+          "language-server",
+        },
+      }, config.options.lspconfig.options)
+    )
+    vim.lsp.enable("phpactor")
   end
 end
 

--- a/spec/init.lua
+++ b/spec/init.lua
@@ -28,7 +28,6 @@ function M.setup()
   vim.opt.packpath = { M.root(".spec/site") }
 
   M.load("nvim-lua/plenary.nvim")
-  M.load("neovim/nvim-lspconfig")
 
   require("phpactor").setup({
     install = {


### PR DESCRIPTION
### What was done
- Migration of LSP configuration to Neovim's native API
- Removal of the `require(“lspconfig”).setup` call
- Removal of the `lspconfig` plugin dependency

### Reason
Neovim now provides a native API for enabling LSP, making the use of the `lspconfig` plugin unnecessary in this case.

### Impact
- Fixes the warning message about the deprecation of the `lspconfig().setup()` call